### PR TITLE
Less spammy script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
 #See the restaurants.txt file for the list of available restaurants. Case sensitive!
-RESTAURANTS = Chemicum, Biokeskus, Täffä
+RESTAURANTS = Chemicum, Biokeskus 3, Täffä

--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ Instructions:
 
 - pip install -r requirements.txt
 
-- chmod +777 getdata.sh
+- chmod +r getdata.sh
 
 - ./getdata.sh, and check data.txt for success

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-A script to fetch food data from Kanttiinit.fi API kitchen.kanttiinit.fi
+A script to fetch food data from Kanttiinit.fi API kitchen.kanttiinit.fi. getMap.py fetches the current mapping between all restaurants and their ID, and menuGet.py gets the relevant menus specified in .env.
 
 Instructions:
 

--- a/getMap.py
+++ b/getMap.py
@@ -1,0 +1,33 @@
+#Map all restaurants to their IDs. Used later to not spam API with requests.
+import requests
+import json
+import time
+
+def get_restaurants():
+    url1 = "https://kitchen.kanttiinit.fi/restaurants/"
+    url2 = "/menu"
+
+    map = {}
+
+    for i in range(1, 100):  # Assuming there are at max 100 restaurants (as is the case 9/6/25):
+
+        time.sleep(0.1) #Add small delay to avoid overwhelming the server
+
+        try:
+            url = url1+str(i)+url2
+            response = requests.get(url)
+            response.raise_for_status()
+            data = response.json() 
+
+            map[data['name'].strip()] = int(data['id'])
+        except (requests.RequestException, ValueError):
+            continue  
+    
+    res1 = ""
+    for key,val in map.items():
+        res1 += f"{key.strip()},{val}\n"
+    with open("restaurants.txt", "w", encoding="utf-8") as f:
+        f.write(res1)
+
+if __name__ == "__main__":
+    get_restaurants()

--- a/getdata.sh
+++ b/getdata.sh
@@ -7,26 +7,27 @@
 TIME_TO_SLEEP=60 # seconds
 RETRY_TIMES=10 # number of retries
 
-CURRENT_DIR=$(pwd)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 #!/bin/bash
 while true; do
     wget -q --spider http://google.com
     if [ $? -eq 0 ]; then
-        python3 $CURRENT_DIR/getMap.py 
+        python3 $SCRIPT_DIR/getMap.py 
         break
     else
         sleep $TIME_TO_SLEEP
         RETRY_TIMES=$((RETRY_TIMES - 1))
         if [ $RETRY_TIMES -le 0 ]; then
-            echo "No internet connection after multiple attempts. Exiting." > $CURRENT_DIR/data.txt
+            echo "No internet connection after multiple attempts. Exiting." > $SCRIPT_DIR/data.txt
             exit 1
         fi
     fi
 done 
 
 while true; do
-    python3 $CURRENT_DIR/kanttiinitgrep.py > $CURRENT_DIR/data.txt
+    python3 $SCRIPT_DIR/kanttiinitgrep.py > $SCRIPT_DIR/data.txt
     sleep 3600
     #Sleep for 1 hour before running the script again, checking only the restaurants which are listed in .env
 done

--- a/getdata.sh
+++ b/getdata.sh
@@ -10,13 +10,11 @@ RETRY_TIMES=10 # number of retries
 CURRENT_DIR=$(pwd)
 
 #!/bin/bash
-
 while true; do
     wget -q --spider http://google.com
     if [ $? -eq 0 ]; then
-        #internet connection is available
-        python3 $CURRENT_DIR/kanttiinitgrep.py > $CURRENT_DIR/data.txt
-        exit 0
+        python3 $CURRENT_DIR/getMap.py 
+        break
     else
         sleep $TIME_TO_SLEEP
         RETRY_TIMES=$((RETRY_TIMES - 1))
@@ -24,6 +22,11 @@ while true; do
             echo "No internet connection after multiple attempts. Exiting." > $CURRENT_DIR/data.txt
             exit 1
         fi
-        #echo "No internet connection. Retrying in $TIME_TO_SLEEP seconds..."
     fi
+done 
+
+while true; do
+    python3 $CURRENT_DIR/kanttiinitgrep.py > $CURRENT_DIR/data.txt
+    sleep 3600
+    #Sleep for 1 hour before running the script again, checking only the restaurants which are listed in .env
 done

--- a/kanttiinitgrep.py
+++ b/kanttiinitgrep.py
@@ -1,19 +1,16 @@
 
 import dotenv
 import os
-from restaurantGet import get_restaurants
+from menuGet import get_menus
 dotenv.load_dotenv()
 res = os.getenv("RESTAURANTS").split(",")
 
-map, foods = get_restaurants()
-wanted_list = ""
+menus = get_menus(res)
 
-for a in res:
-    if a.strip() in foods.keys():
-        wanted_list += a.strip() + "\n"
-        wanted_list += foods[a.strip()]
-        wanted_list += "\n"
-    else:
-        continue
+total = ""
+for key,val in menus.items():
+    total += str(key)
+    total += str(val)
+    total += "\n"
 
-print(wanted_list)
+print(total)

--- a/menuGet.py
+++ b/menuGet.py
@@ -3,26 +3,30 @@ import requests
 import json
 import time
 
-def get_restaurants():
-    #Get the full list of restaurants from the kanttiinit.fi API, along with their menus.
-    #The API is not documented, so this is a best-effort attempt to scrape the data.
+def get_menus(wanted):
     url1 = "https://kitchen.kanttiinit.fi/restaurants/"
     url2 = "/menu"
 
-    map = {} #Mapping of restaurant names to their IDs, if needed
-    foods = {}  #Actual food items, indexed by restaurant name
+    menus = {} 
 
-    for i in range(1, 100):  # Assuming there are at max 100 restaurants (as is the case 9/6/25):
+    entries =  {}
+    with open("restaurants.txt", "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                a, b = line.split(",")
+                entries[a.strip()] = int(b.strip())
 
-        time.sleep(0.1) #Add small delay to avoid overwhelming the server
+    for a in wanted:  
+
+        time.sleep(0.1) 
 
         try:
-            url = url1+str(i)+url2
+            url = url1+str(entries[a.strip()])+url2
             response = requests.get(url)
             response.raise_for_status()
             data = response.json() 
 
-            map[data['name'].strip()] = int(data['id'])
             if data['menus']:
                 #If a menu exists, add its relevant items to the foods dictionary as a print-ready string
                 ruokalista = "" #Construct a printable list of food items with their properties
@@ -31,16 +35,10 @@ def get_restaurants():
                     ruokalista += item['title'] + " "
                     ruokalista += ", ".join(item['properties']) 
                     ruokalista += "\n"
-                foods[data['name'].strip()] = ruokalista
+                menus[data['name'].strip()+":\n"] = ruokalista
             else:
-                foods[data['name'].strip()] = "Ei ruokaa tänään\n"
+                menus[data['name'].strip()+":\n"] = "Ei ruokaa tänään\n"
         except (requests.RequestException, ValueError):
             continue  
     
-    res = ""
-    for key in map.keys():
-        res += f"{key.strip()}\n"
-    with open("restaurants.txt", "w", encoding="utf-8") as f:
-        f.write(res)
-
-    return (map, foods)
+    return(menus)

--- a/restaurants.txt
+++ b/restaurants.txt
@@ -1,54 +1,54 @@
-Kvarkki
-Tietotekniikantalo
-Täffä
-Alvari
-TUAS
-Aalto Valimo
-Kaivopiha
-Cafe Portaali
-Metsätalo
-Olivia
-Ravintola Serpens
-UniCafe Päärakennus
-Ravintola Fredrika Päärakennus
-Hanken
-Soc&Kom
-Hämäläis-Osakunta
-Porthania
-Chemicum
-Exactum
-Physicum
-Biokeskus 3
-Korona
-Viikuna
-Ladonlukko
-Tähkä
-Mau-kas
-Kookos
-Dipoli Ravintolat
-Biomedicum
-UniCafe Meilahti
-Kipsari Väre
-A Bloc
-Musiikkitalon Klubi
-Metropolia Leiritie
-DIAK-Kalasatama
-Unicafe Ruskeasuo
-Ravintola Agora
-Arvo
-Pesco & Vege Topelias
-Ravintola Oliver
-Rotunda
-Metropolia Myllypuro
-Luova
-Töölö 37
-Arabianranta
-Helsingin yliopisto Päärakennus
-Myöhä Café & Bar
-Chemicum Opettajien ravintola
-Mau-kas Nova
-Kaisa-talo
-Infokeskus alakerta
-Tempo
-Biokeskus
-Arcada
+Kvarkki,1
+Tietotekniikantalo,2
+Täffä,3
+Alvari,5
+TUAS,7
+Aalto Valimo,8
+Kaivopiha,12
+Cafe Portaali,13
+Metsätalo,16
+Olivia,17
+Ravintola Serpens,18
+UniCafe Päärakennus,19
+Ravintola Fredrika Päärakennus,20
+Hanken,24
+Soc&Kom,25
+Hämäläis-Osakunta,26
+Porthania,27
+Chemicum,32
+Exactum,33
+Physicum,34
+Biokeskus 3,35
+Korona,36
+Viikuna,37
+Ladonlukko,38
+Tähkä,39
+Mau-kas,41
+Kookos,42
+Dipoli Ravintolat,45
+Biomedicum,47
+UniCafe Meilahti,49
+Kipsari Väre,50
+A Bloc,52
+Musiikkitalon Klubi,53
+Metropolia Leiritie,54
+DIAK-Kalasatama,55
+Unicafe Ruskeasuo,56
+Ravintola Agora,57
+Arvo,59
+Pesco & Vege Topelias,61
+Ravintola Oliver,62
+Rotunda,63
+Metropolia Myllypuro,65
+Luova,66
+Töölö 37,67
+Arabianranta,68
+Helsingin yliopisto Päärakennus,69
+Myöhä Café & Bar,71
+Chemicum Opettajien ravintola,72
+Mau-kas Nova,73
+Kaisa-talo,74
+Infokeskus alakerta,75
+Tempo,80
+Biokeskus,81
+Arcada,82


### PR DESCRIPTION
Changed that the mapping between restaurants and IDs is fetched only once, after which only restaurants given in .env are fetched. Also, made the shell-script run forever, waiting an hour between iterations, so no need to restart every hour.